### PR TITLE
 teamd: Add ZeroMQ interface.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -76,6 +76,19 @@ AC_ARG_ENABLE([dbus],
 	fi
 fi
 
+have_zmq=no
+AC_ARG_ENABLE([zmq],
+        AS_HELP_STRING([--disable-zmq], [disable ZeroMQ API @<:@default=enabled@:>@]))
+        if test "x$enable_zmq" != "xno"; then
+                PKG_CHECK_MODULES([ZMQ], [libzmq],
+                                  [AC_DEFINE(ENABLE_ZMQ, [1], [ZMQ API.]) have_zmq=yes],
+                                  have_zmq=no)
+        if test "x$have_zmq$enable_zmq" = xnoyes; then
+                AC_MSG_ERROR([*** ZeroMQ support requested but libraries not found])
+        fi
+fi
+
+
 AC_CONFIG_FILES([Makefile
 include/Makefile \
 libteam/Makefile \

--- a/include/teamdctl.h
+++ b/include/teamdctl.h
@@ -43,7 +43,7 @@ void teamdctl_set_log_fn(struct teamdctl *tdc,
 int teamdctl_get_log_priority(struct teamdctl *tdc);
 void teamdctl_set_log_priority(struct teamdctl *tdc, int priority);
 int teamdctl_connect(struct teamdctl *tdc, const char *team_name,
-		     const char *cli_type);
+		     const char* addr, const char *cli_type);
 void teamdctl_disconnect(struct teamdctl *tdc);
 int teamdctl_refresh(struct teamdctl *tdc);
 int teamdctl_port_add(struct teamdctl *tdc, const char *port_devname);

--- a/libteamdctl/Makefile.am
+++ b/libteamdctl/Makefile.am
@@ -6,9 +6,9 @@ AM_CFLAGS = -fvisibility=hidden -ffunction-sections -fdata-sections
 AM_LDFLAGS = -Wl,--gc-sections -Wl,--as-needed
 
 lib_LTLIBRARIES = libteamdctl.la
-libteamdctl_la_SOURCES = libteamdctl.c cli_usock.c cli_dbus.c
+libteamdctl_la_SOURCES = libteamdctl.c cli_usock.c cli_dbus.c cli_zmq.c
 libteamdctl_la_CFLAGS= $(AM_CFLAGS) $(JANSSON_CFLAGS) $(DBUS_CFLAGS) -I${top_srcdir}/include -D_GNU_SOURCE
-libteamdctl_la_LIBADD= $(JANSSON_LIBS) $(DBUS_LIBS)
+libteamdctl_la_LIBADD= $(JANSSON_LIBS) $(DBUS_LIBS) $(ZMQ_LIBS) $(LIBDAEMON_LIBS)
 libteamdctl_la_LDFLAGS = $(AM_LDFLAGS) -version-info @LIBTEAMDCTL_CURRENT@:@LIBTEAMDCTL_REVISION@:@LIBTEAMDCTL_AGE@
 
 pkgconfigdir = $(libdir)/pkgconfig

--- a/libteamdctl/libteamdctl.c
+++ b/libteamdctl/libteamdctl.c
@@ -226,7 +226,7 @@ static void cli_fini(struct teamdctl *tdc)
  **/
 TEAMDCTL_EXPORT
 int teamdctl_connect(struct teamdctl *tdc, const char *team_name,
-		     const char *cli_type)
+		     const char * addr, const char *cli_type)
 {
 	int err;
 	int i;
@@ -234,6 +234,9 @@ int teamdctl_connect(struct teamdctl *tdc, const char *team_name,
 		teamdctl_cli_usock_get(),
 #ifdef ENABLE_DBUS
 		teamdctl_cli_dbus_get(),
+#endif
+#ifdef ENABLE_ZMQ
+		teamdctl_cli_zmq_get(),
 #endif
 	};
 #define TEAMDCTL_CLI_LIST_SIZE ARRAY_SIZE(teamdctl_cli_list)
@@ -257,6 +260,8 @@ int teamdctl_connect(struct teamdctl *tdc, const char *team_name,
 		 */
 		if (!cli_type && orig_log_prio < LOG_DEBUG)
 			teamdctl_set_log_priority(tdc, LOG_EMERG);
+
+		tdc->addr = (char*)addr;
 
 		err = cli_init(tdc, team_name);
 

--- a/libteamdctl/teamdctl_private.h
+++ b/libteamdctl/teamdctl_private.h
@@ -40,6 +40,7 @@ struct teamdctl {
 		       const char *file, int line, const char *fn,
 		       const char *format, va_list args);
 	int log_priority;
+	char *addr;
 	const struct teamdctl_cli *cli;
 	void *cli_priv;
 	struct {
@@ -97,6 +98,7 @@ struct teamdctl_cli {
 
 const struct teamdctl_cli *teamdctl_cli_usock_get(void);
 const struct teamdctl_cli *teamdctl_cli_dbus_get(void);
+const struct teamdctl_cli *teamdctl_cli_zmq_get(void);
 
 #define TEAMDCTL_REPLY_TIMEOUT 5000 /* ms */
 

--- a/teamd/Makefile.am
+++ b/teamd/Makefile.am
@@ -8,13 +8,13 @@ AM_CPPFLAGS='-DLOCALSTATEDIR="$(localstatedir)"'
 
 teamd_CFLAGS= $(LIBDAEMON_CFLAGS) $(JANSSON_CFLAGS) $(DBUS_CFLAGS) -I${top_srcdir}/include -D_GNU_SOURCE
 
-teamd_LDADD = $(top_builddir)/libteam/libteam.la $(LIBDAEMON_LIBS) $(JANSSON_LIBS) $(DBUS_LIBS)
+teamd_LDADD = $(top_builddir)/libteam/libteam.la $(LIBDAEMON_LIBS) $(JANSSON_LIBS) $(DBUS_LIBS) $(ZMQ_LIBS)
 
 bin_PROGRAMS=teamd
 teamd_SOURCES=teamd.c teamd_common.c teamd_json.c teamd_config.c teamd_state.c \
 	      teamd_workq.c teamd_events.c teamd_per_port.c \
 	      teamd_option_watch.c teamd_ifinfo_watch.c teamd_link_watch.c \
-	      teamd_ctl.c teamd_dbus.c teamd_usock.c teamd_sriov.c \
+	      teamd_ctl.c teamd_dbus.c teamd_zmq.c teamd_usock.c teamd_sriov.c \
 	      teamd_bpf_chef.c teamd_hash_func.c teamd_balancer.c \
 	      teamd_runner_basic_ones.c teamd_runner_activebackup.c \
 	      teamd_runner_loadbalance.c teamd_runner_lacp.c

--- a/teamd/teamd.c
+++ b/teamd/teamd.c
@@ -49,6 +49,7 @@
 #include "teamd_state.h"
 #include "teamd_usock.h"
 #include "teamd_dbus.h"
+#include "teamd_zmq.h"
 #include "teamd_sriov.h"
 
 static const struct teamd_runner *teamd_runner_list[] = {
@@ -97,7 +98,7 @@ static void print_help(const struct teamd_context *ctx) {
             "    -v --version             Show version\n"
             "    -f --config-file=FILE    Load the specified configuration file\n"
             "    -c --config=TEXT         Use given config string (This causes configuration\n"
-	    "                             file will be ignored)\n"
+            "                             file will be ignored)\n"
             "    -p --pid-file=FILE       Use the specified PID file\n"
             "    -g --debug               Increase verbosity\n"
             "    -r --force-recreate      Force team device recreation in case it\n"
@@ -105,8 +106,11 @@ static void print_help(const struct teamd_context *ctx) {
             "    -t --team-dev=DEVNAME    Use the specified team device\n"
             "    -n --no-ports            Start without ports\n"
             "    -D --dbus-enable         Enable D-Bus interface\n"
+            "    -Z --zmq-enable          Enable ZeroMQ interface\n"
             "    -U --usock-enable        Enable UNIX domain socket interface\n"
-            "    -u --usock-disable       Disable UNIX domain socket interface\n",
+            "    -u --usock-disable       Disable UNIX domain socket interface\n"
+            "    -A --address             Address for connection over UNIX domain socket, ZeroMQ.",
+
             ctx->argv0);
 	printf("Available runners: ");
 	for (i = 0; i < TEAMD_RUNNER_LIST_SIZE; i++) {
@@ -134,12 +138,14 @@ static int parse_command_line(struct teamd_context *ctx,
 		{ "team-dev",		required_argument,	NULL, 't' },
 		{ "no-ports",		no_argument,		NULL, 'n' },
 		{ "dbus-enable",	no_argument,		NULL, 'D' },
+		{ "zmq-enable",		no_argument,		NULL, 'Z' },
 		{ "usock-enable",	no_argument,		NULL, 'U' },
 		{ "usock-disable",	no_argument,		NULL, 'u' },
+		{ "address",		required_argument,	NULL, 'A' },
 		{ NULL, 0, NULL, 0 }
 	};
 
-	while ((opt = getopt_long(argc, argv, "hdkevf:c:p:grt:nDUu",
+	while ((opt = getopt_long(argc, argv, "hdkevf:c:p:grt:nDZ:UuA:",
 				  long_options, NULL)) >= 0) {
 
 		switch(opt) {
@@ -194,6 +200,15 @@ static int parse_command_line(struct teamd_context *ctx,
 			return -1;
 #else
 			ctx->dbus.enabled = true;
+#endif
+			break;
+		case 'Z':
+#ifndef ENABLE_ZMQ
+			fprintf(stderr, "ZeroMQ support is not compiled-in\n");
+			return -1;
+#else
+			ctx->zmq.enabled = true;
+			ctx->zmq.addr = optarg;
 #endif
 			break;
 		case 'U':
@@ -1189,10 +1204,16 @@ static int teamd_init(struct teamd_context *ctx)
 		goto usock_fini;
 	}
 
+	err = teamd_zmq_init(ctx);
+	if (err) {
+		teamd_log_err("Failed to init zmq.");
+		goto dbus_fini;
+	}
+
 	err = teamd_add_ports(ctx);
 	if (err) {
 		teamd_log_err("Failed to add ports.");
-		goto dbus_fini;
+		goto zmq_fini;
 	}
 
 	/*
@@ -1202,11 +1223,12 @@ static int teamd_init(struct teamd_context *ctx)
 	err = teamd_dbus_expose_name(ctx);
 	if (err) {
 		teamd_log_err("Failed to expose dbus name.");
-		goto dbus_fini;
+		goto zmq_fini;
 	}
 
 	return 0;
-
+zmq_fini:
+	teamd_zmq_fini(ctx);
 dbus_fini:
 	teamd_dbus_fini(ctx);
 usock_fini:
@@ -1246,6 +1268,7 @@ team_free:
 
 static void teamd_fini(struct teamd_context *ctx)
 {
+	teamd_zmq_fini(ctx);
 	teamd_dbus_fini(ctx);
 	teamd_usock_fini(ctx);
 	teamd_sriov_fini(ctx);

--- a/teamd/teamd.h
+++ b/teamd/teamd.h
@@ -42,6 +42,10 @@
 #include <dbus/dbus.h>
 #endif
 
+#ifdef ENABLE_ZMQ
+#include <zmq.h>
+#endif
+
 #define teamd_log_err(args...) daemon_log(LOG_ERR, ##args)
 #define teamd_log_warn(args...) daemon_log(LOG_WARNING, ##args)
 #define teamd_log_info(args...) daemon_log(LOG_INFO, ##args)
@@ -126,6 +130,14 @@ struct teamd_context {
 		bool			enabled;
 		DBusConnection *	con;
 	} dbus;
+#endif
+#ifdef ENABLE_ZMQ
+	struct {
+		bool			enabled;
+		void *			context;
+		void *			sock;
+		char *			addr;
+	} zmq;
 #endif
 	struct {
 		bool			enabled;

--- a/teamd/teamd_state.c
+++ b/teamd/teamd_state.c
@@ -617,6 +617,18 @@ static int setup_state_dbus_enabled_get(struct teamd_context *ctx,
 	return 0;
 }
 
+static int setup_state_zmq_enabled_get(struct teamd_context *ctx,
+					struct team_state_gsc *gsc,
+					void *priv)
+{
+#ifdef ENABLE_ZMQ
+	gsc->data.bool_val = ctx->zmq.enabled;
+#else
+	gsc->data.bool_val = false;
+#endif
+	return 0;
+}
+
 static int setup_state_debug_level_get(struct teamd_context *ctx,
 				       struct team_state_gsc *gsc,
 				       void *priv)
@@ -664,6 +676,11 @@ static const struct teamd_state_val setup_state_vals[] = {
 		.subpath = "dbus_enabled",
 		.type = TEAMD_STATE_ITEM_TYPE_BOOL,
 		.getter = setup_state_dbus_enabled_get,
+	},
+	{
+		.subpath = "zmq_enabled",
+		.type = TEAMD_STATE_ITEM_TYPE_BOOL,
+		.getter = setup_state_zmq_enabled_get,
 	},
 	{
 		.subpath = "debug_level",

--- a/utils/teamdctl.c
+++ b/utils/teamdctl.c
@@ -148,17 +148,19 @@ static int stateview_json_setup_process(char **prunner_name, json_t *dump_json)
 	char *runner_name;
 	char *kernel_team_mode_name;
 	int dbus_enabled;
+	int zmq_enabled;
 	int debug_level;
 	int daemonized;
 	int pid;
 	char *pid_file;
 
 	pr_out("setup:\n");
-	err = json_unpack(dump_json, "{s:{s:s, s:s, s:b, s:i, s:b, s:i, s:s}}",
+	err = json_unpack(dump_json, "{s:{s:s, s:s, s:b, s:b, s:i, s:b, s:i, s:s}}",
 			  "setup",
 			  "runner_name", &runner_name,
 			  "kernel_team_mode_name", &kernel_team_mode_name,
 			  "dbus_enabled", &dbus_enabled,
+			  "zmq_enabled", &zmq_enabled,
 			  "debug_level", &debug_level,
 			  "daemonized", &daemonized,
 			  "pid", &pid,
@@ -171,6 +173,7 @@ static int stateview_json_setup_process(char **prunner_name, json_t *dump_json)
 	pr_out("runner: %s\n", runner_name);
 	pr_out2("kernel team mode: %s\n", kernel_team_mode_name);
 	pr_out2("D-BUS enabled: %s\n", boolyesno(dbus_enabled));
+	pr_out2("ZeroMQ enabled: %s\n", boolyesno(zmq_enabled));
 	pr_out2("debug level: %d\n", debug_level);
 	pr_out2("daemonized: %s\n", boolyesno(daemonized));
 	pr_out2("PID: %d\n", pid);
@@ -876,6 +879,33 @@ static int check_team_devname(char *team_devname)
 	return 0;
 }
 
+
+static int check_teamd_team_devname(struct teamdctl *tdc, char *team_devname)
+{
+	int ret = 0;
+	json_t* root;
+	json_error_t error;
+	json_t* j_device_name;
+	char* teamd_device_name;
+
+	root = json_loads(teamdctl_config_get_raw(tdc), 0, &error);
+	j_device_name = json_object_get(root, "device");
+
+	teamd_device_name = json_string_value(j_device_name);
+
+	if (strcmp(team_devname, teamd_device_name) != 0){
+		pr_err("Unable to access to %s through connected teamd daemon"
+		       " because daemon controls %s.\n", team_devname,
+		       teamd_device_name);
+		ret = -1;
+	}
+
+	json_decref(j_device_name);
+	json_decref(root);
+	return ret;
+}
+
+
 static int call_command(struct teamdctl *tdc, int argc, char **argv,
 			struct command_type *command_type)
 {
@@ -900,7 +930,9 @@ static void print_help(const char *argv0) {
 	       "    -v --verbose             Increase output verbosity\n"
 	       "    -o --oneline             Force output to one line if possible\n"
 	       "    -D --force-dbus          Force to use D-Bus interface\n"
-	       "    -U --force-usock         Force to use UNIX domain socket interface\n",
+	       "    -Z --force-zmq           Force to use ZeroMQ interface [-Z[Address]]\n"
+	       "    -U --force-usock         Force to use UNIX domain socket interface\n"
+	       "    -A --address             Address for connection over UNIX domain socket, ZeroMQ.",
             argv0);
 	pr_out("Commands:\n");
 	for (i = 0; i < COMMAND_TYPE_COUNT; i++) {
@@ -924,6 +956,7 @@ int main(int argc, char **argv)
 		{ "verbose",		no_argument,		NULL, 'v' },
 		{ "oneline",		no_argument,		NULL, 'o' },
 		{ "force-dbus",		no_argument,		NULL, 'D' },
+		{ "force-zmq",		required_argument,	NULL, 'Z' },
 		{ "force-usock",	no_argument,		NULL, 'U' },
 		{ NULL, 0, NULL, 0 }
 	};
@@ -932,10 +965,12 @@ int main(int argc, char **argv)
 	struct command_type *command_type;
 	struct teamdctl *tdc;
 	int ret;
+	char* addr = NULL;
 	bool force_dbus = false;
+	bool force_zmq = false;
 	bool force_usock = false;
 
-	while ((opt = getopt_long(argc, argv, "hvoDU",
+	while ((opt = getopt_long(argc, argv, "hvoDZ:U",
 				  long_options, NULL)) >= 0) {
 
 		switch(opt) {
@@ -956,6 +991,15 @@ int main(int argc, char **argv)
 			force_dbus = true;
 #endif
 			break;
+		case 'Z':
+#ifndef ENABLE_ZMQ
+			fprintf(stderr, "ZeroMQ support is not compiled-in\n");
+			return EXIT_FAILURE;
+#else
+			force_zmq = true;
+			addr = optarg;
+#endif
+			break;
 		case 'U':
 			force_usock = true;
 			break;
@@ -970,8 +1014,8 @@ int main(int argc, char **argv)
 		}
 	}
 
-	if (force_usock && force_dbus) {
-		pr_err("Either UNIX domain socket interface or D-Bus interface can be forced at a time.\n");
+	if ((int)force_usock + (int)force_dbus + (int)force_zmq > 1) {
+		pr_err("Only one interface could be forced at a time (UNIX domain socket, D-Bus, ZMQ).\n");
 		print_help(argv0);
 		return EXIT_FAILURE;
 	}
@@ -1005,13 +1049,20 @@ int main(int argc, char **argv)
 		pr_err("teamdctl_alloc failed\n");
 		return EXIT_FAILURE;
 	}
-	err = teamdctl_connect(tdc, team_devname,
-			       force_usock ? "usock" : (force_dbus ? "dbus" : NULL));
+
+	err = teamdctl_connect(tdc, team_devname, addr,
+			       force_usock ? "usock" : (force_dbus ? "dbus" :  (force_zmq ? "zmq" :NULL)));
 	if (err) {
 		pr_err("teamdctl_connect failed (%s)\n", strerror(-err));
 		ret = EXIT_FAILURE;
 		goto teamdctl_free;
 	}
+
+	if (check_teamd_team_devname(tdc, team_devname)){
+		ret = EXIT_FAILURE;
+		goto teamdctl_disconnect;
+	}
+
 	err = call_command(tdc, argc, argv, command_type);
 	if (err) {
 		pr_err("command call failed (%s)\n", strerror(-err));


### PR DESCRIPTION
enable ZeroMQ interface

teamd -Z "tcp:\127.0.0.1:5555"
teamdctl -Z "tcp:\127.0.0.1:5555" config dump

Take care when you use this type of connection.
Security must be ensured by firewall or other tools.
There could be added verification by certificate with SSL layer.
It could be added in next version.

Signed-off-by: Jiří Župka jzupka@redhat.com
