### PR TITLE
utils: teamdctl needs to be linked with jansson

### DIFF
--- a/utils/Makefile.am
+++ b/utils/Makefile.am
@@ -5,7 +5,7 @@ ACLOCAL_AMFLAGS = -I m4
 AM_CFLAGS = -I${top_srcdir}/include
 
 teamnl_LDADD = $(top_builddir)/libteam/libteam.la
-teamdctl_LDADD = $(top_builddir)/libteamdctl/libteamdctl.la
+teamdctl_LDADD = $(top_builddir)/libteamdctl/libteamdctl.la $(JANSSON_LIBS)
 
 bin_PROGRAMS=teamnl teamdctl
 teamnl_SOURCES=teamnl.c


### PR DESCRIPTION
This happens with the following configure line:

```
./configure --build=x86_64-linux-gnu --prefix=/usr --includedir=${prefix}/include \
            --mandir=${prefix}/share/man --infodir=${prefix}/share/info \
            --sysconfdir=/etc --localstatedir=/var \
            --libdir=${prefix}/lib/x86_64-linux-gnu \
            --libexecdir=${prefix}/lib/x86_64-linux-gnu \
            --disable-maintainer-mode --disable-dependency-tracking \
            --disable-silent-rules --enable-static=no
```

And with the following CFLAGS:

```
CFLAGS='-g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security'
CPPFLAGS=-D_FORTIFY_SOURCE=2
LDFLAGS=-Wl,-z,relro
```

Those are hardening flags used commonly in distros today.
