### PR TITLE
Do not fail teamd_add_ports() when one port is missing

### DIFF
--- a/teamd/teamd_per_port.c
+++ b/teamd/teamd_per_port.c
@@ -340,6 +340,11 @@ int teamd_port_add_ifname(struct teamd_context *ctx, const char *port_name)
 	teamd_log_dbg("%s: Adding port (found ifindex \"%d\").",
 		      port_name, ifindex);
 	err = team_port_add(ctx->th, ifindex);
+	if (err == -ENODEV) {
+		teamd_log_err("%s: Failed to add missing port.", port_name);
+		return 0;
+	}
+
 	if (err)
 		teamd_log_err("%s: Failed to add port.", port_name);
 	return err;


### PR DESCRIPTION
When multiple ports are specified in the config and one of
them is not present (e.g. usb2eth device) during team instance
start up time, instead of failing the whole setup, just report
failure with a missing port and carry on with the rest.

Signed-off-by: Pawel Wieczorkiewicz <pwieczorkiewicz@suse.de>