### PR TITLE
Fix TEAM_OPTION_TYPE_BOOL type for big endian architectures

### DIFF
--- a/libteam/options.c
+++ b/libteam/options.c
@@ -259,6 +259,7 @@ int get_options_handler(struct nl_msg *msg, void *arg)
 		int nla_type;
 		int opt_type;
 		long tmp;
+		bool tmp_bool;
 		void *data;
 		int data_len = 0;
 		int err;
@@ -317,8 +318,8 @@ int get_options_handler(struct nl_msg *msg, void *arg)
 			opt_type = TEAM_OPTION_TYPE_BINARY;
 			break;
 		case NLA_FLAG:
-			tmp = (long) (data_attr ? true : false);
-			data = &tmp;
+			tmp_bool = (bool) (data_attr ? true : false);
+			data = &tmp_bool;
 			opt_type = TEAM_OPTION_TYPE_BOOL;
 			break;
 		case NLA_S32:


### PR DESCRIPTION
The `TEAM_OPTION_TYPE_BOOL` is handled as a `bool` in the kernel and as a `long` in userspace. On a little endian architecture this is not a problem, but on a big endian architecture the result will not be correct.