### PR TITLE
fix redefinition of 'struct ethhdr' in musl libc

### DIFF
--- a/teamd/teamd_lw_arp_ping.c
+++ b/teamd/teamd_lw_arp_ping.c
@@ -20,7 +20,11 @@
 
 #include <arpa/inet.h>
 #include <net/if_arp.h>
+#if defined(__GLIBC__)
 #include <linux/if_ether.h>
+#else
+#include <net/ethernet.h>
+#endif
 #include <netdb.h>
 #include <private/misc.h>
 #include "teamd.h"

--- a/teamd/teamd_lw_nsna_ping.c
+++ b/teamd/teamd_lw_nsna_ping.c
@@ -21,7 +21,11 @@
 #include <netdb.h>
 #include <netinet/ip6.h>
 #include <netinet/icmp6.h>
+#if defined(__GLIBC__)
 #include <linux/if_ether.h>
+#else
+#include <net/ethernet.h>
+#endif
 #include <private/misc.h>
 #include "teamd.h"
 #include "teamd_link_watch.h"

--- a/teamd/teamd_runner_lacp.c
+++ b/teamd/teamd_runner_lacp.c
@@ -23,14 +23,20 @@
 #include <unistd.h>
 #include <limits.h>
 #include <sys/ioctl.h>
+#if defined(__GLIBC__)
 #include <linux/if_ether.h>
+#else
+#include <net/ethernet.h>
+#endif
 #include <sys/socket.h>
 #include <linux/netdevice.h>
 #include <netinet/in.h>
 #include <errno.h>
 #include <team.h>
 #include <private/misc.h>
+#if defined(__GLIBC__)
 #include <net/ethernet.h>
+#endif
 
 #include "teamd.h"
 #include "teamd_config.h"


### PR DESCRIPTION
Under **musl libc** mixing `kernel` & `userspace ethernet` headers causes:

`error: redefinition of 'struct ethhdr'`

fixes compilation with **musl libc**
