### PR TITLE
fix finding element in path by name

### DIFF
--- a/teamd/teamd_state.c
+++ b/teamd/teamd_state.c
@@ -306,8 +306,9 @@ static int __find_by_item_path(struct teamd_state_val_item **p_item,
 		subpath = ifname_end + 1;
 
 		teamd_for_each_tdport(cur_tdport, ctx) {
+			size_t curname_len = strlen(cur_tdport->ifname);
 			if (!strncmp(cur_tdport->ifname, ifname_start,
-				     ifname_len)) {
+				     ((ifname_len>curname_len)?ifname_len:curname_len))) {
 				tdport = cur_tdport;
 				break;
 			}


### PR DESCRIPTION
Fix problem with retrieving state item value per interface name,
when some member interface names partially match to one another.
Like `eth1` and `eth11`, or `eth1` with `eth10`