### PR TITLE
teamd: Include missing headers for strrchr and memcmp

### DIFF
--- a/teamd/teamd_phys_port_check.c
+++ b/teamd/teamd_phys_port_check.c
@@ -19,6 +19,7 @@
 
 #include <stdio.h>
 #include <errno.h>
+#include <string.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>

--- a/teamd/teamd_runner_loadbalance.c
+++ b/teamd/teamd_runner_loadbalance.c
@@ -17,6 +17,7 @@
  *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
+#include <string.h>
 #include <sys/socket.h>
 #include <linux/netdevice.h>
 #include <team.h>


### PR DESCRIPTION
Compiler does not see the prototype for these functions otherwise and
build fails e.g.

| ../../git/teamd/teamd_phys_port_check.c:52:10: error: call to undeclared library function 'strrchr' with type 'char *(const char *, int)'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
|         start = strrchr(link, '/');
|                 ^

Signed-off-by: Khem Raj <raj.khem@gmail.com>