### PR TITLE
man: fix error options in teamd man doc

### DIFF
--- a/man/teamd.8
+++ b/man/teamd.8
@@ -31,7 +31,7 @@ teamd \(em team network device control daemon
 .IR address ]
 .br
 .B teamd
-.BR  \-h | \-V
+.BR  \-h | \-v
 .SH DESCRIPTION
 .PP
 teamd is a daemon to control a given team network device, during runtime,
@@ -44,7 +44,7 @@ libteam project.
 .B "\-h, \-\-help"
 Print help text to console and exit.
 .TP
-.B "\-V, \-\-version"
+.B "\-v, \-\-version"
 Print version information to console and exit.
 .TP
 .B "\-d, \-\-daemonize"


### PR DESCRIPTION
teamd has option "-v": print version.
```
[root@localhost ~]# teamd -v
teamd 1.31
[root@localhost ~]# teamd -V
teamd: invalid option -- 'V'
```
but in man doc: 
-V, --version
              Print version information to console and exit.

Signed-off-by: Bin Hu <im.bin.hu@gmail.com>