### PR TITLE
teamd: make -NN not flush the ports

### DIFF
--- a/man/teamd.8
+++ b/man/teamd.8
@@ -80,6 +80,7 @@ Take over the device if it already exists.
 .TP
 .B "\-N, \-\-no-quit-destroy"
 This option also ensures that the team device is not removed after teamd finishes.
+Repeating the option causes the ports to stay in place.
 .TP
 .BI "\-t " devicename ", \-\-team-dev " devicename
 Use the specified team device name (overrides "device" key in the configuration).

--- a/teamd/teamd.h
+++ b/teamd/teamd.h
@@ -102,7 +102,7 @@ struct teamd_context {
 	char *				log_output;
 	bool				force_recreate;
 	bool				take_over;
-	bool				no_quit_destroy;
+	unsigned int			no_quit_destroy;
 	bool				init_no_ports;
 	bool				pre_add_ports;
 	char *				config_file;


### PR DESCRIPTION
Add a possibility to terminate while leaving the team and the port intact. This is useful when running from NetworkManager which keeps tracks of the ports themselves.

There's one important use case where this is essential: handover from initrd to real root. Systemd's isolation of swithch-root.target stops NetworkManager.service and then terminates its kids, including teamd. The real NetworkManager.service would eventually catch up and restart it, but there's a short period when team ports are removed which is not great if we're booting off that device. Also, it may be that ports come up in different order, causing team to get a different MAC address, which will invalidate the DHCP lease we got beforehands and screwing up L3 addressing.

Let's also not add new option for this purpose, to save poor NetworkManager from unpleasantness of determining whether teamd supports it. The worst that could happen, with new NetworkManager and old teamd, is that things will behave the the way they always did.

Related NetworkManager change:
https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/merge_requests/1360

Signed-off-by: Lubomir Rintel <lkundrak@v3.sk>